### PR TITLE
Remove unzip from dependencies

### DIFF
--- a/satysfi.rb
+++ b/satysfi.rb
@@ -6,7 +6,6 @@ class Satysfi < Formula
   depends_on "ocaml" => :build
   depends_on "opam" => :build
   depends_on "wget" => :build
-  depends_on "unzip" => :build
   depends_on "autoconf" => :build
 
   def install


### PR DESCRIPTION
`unzip` is already bundled with macOS.